### PR TITLE
Close file before renaming it

### DIFF
--- a/autofile/group.go
+++ b/autofile/group.go
@@ -224,15 +224,17 @@ func (g *Group) RotateFile() {
 	g.mtx.Lock()
 	defer g.mtx.Unlock()
 
-	dstPath := filePathForIndex(g.Head.Path, g.maxIndex, g.maxIndex+1)
-	err := os.Rename(g.Head.Path, dstPath)
-	if err != nil {
+	headPath := g.Head.Path
+
+	if err := g.Head.closeFile(); err != nil {
 		panic(err)
 	}
-	err = g.Head.closeFile()
-	if err != nil {
+
+	indexPath := filePathForIndex(headPath, g.maxIndex, g.maxIndex+1)
+	if err := os.Rename(headPath, indexPath); err != nil {
 		panic(err)
 	}
+
 	g.maxIndex += 1
 }
 


### PR DESCRIPTION
this might fix our windows bug https://github.com/tendermint/tendermint/issues/444

https://github.com/Netflix-Skunkworks/go-jira/commit/0980f8e1972a942e505b1939935adf0f7a71f387

Backport of https://github.com/tendermint/go-autofile/pull/3