### PR TITLE
Squash module keyvals if multiple keyvals were provided

### DIFF
--- a/log/tm_logger.go
+++ b/log/tm_logger.go
@@ -10,7 +10,8 @@ import (
 )
 
 const (
-	msgKey = "_msg" // "_" prefixed to avoid collisions
+	msgKey    = "_msg" // "_" prefixed to avoid collisions
+	moduleKey = "module"
 )
 
 type tmLogger struct {

--- a/log/tmfmt_logger.go
+++ b/log/tmfmt_logger.go
@@ -88,7 +88,7 @@ func (l tmfmtLogger) Log(keyvals ...interface{}) error {
 	//     D										- first character of the level, uppercase (ASCII only)
 	//     [05-02|11:06:44.322] - our time format (see https://golang.org/src/time/format.go)
 	//     Stopping ...					- message
-	enc.buf.WriteString(fmt.Sprintf("%c[%s] %-44s", lvl[0]-32, time.Now().UTC().Format("01-02|15:04:05.000"), msg))
+	enc.buf.WriteString(fmt.Sprintf("%c[%s] %-44s ", lvl[0]-32, time.Now().UTC().Format("01-02|15:04:05.000"), msg))
 
 	if module != "unknown" {
 		enc.buf.WriteString("module=" + module + " ")

--- a/log/tmfmt_logger_test.go
+++ b/log/tmfmt_logger_test.go
@@ -44,6 +44,12 @@ func TestTMFmtLogger(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Regexp(t, regexp.MustCompile(`N\[.+\] Hello \s+\n$`), buf.String())
+
+	buf.Reset()
+	if err := logger.Log("module", "main", "module", "crypto", "module", "wire"); err != nil {
+		t.Fatal(err)
+	}
+	assert.Regexp(t, regexp.MustCompile(`N\[.+\] unknown \s+module=wire\s+\n$`), buf.String())
 }
 
 func BenchmarkTMFmtLoggerSimple(b *testing.B) {


### PR DESCRIPTION
**last keyvalue wins**

**Pros**:
- still fast
```
BenchmarkTMLoggerSimple-2                 300000              5953 ns/op             721 B/op       15 allocs/op
BenchmarkTMLoggerContextual-2             200000              6463 ns/op            1073 B/op       21 allocs/op
BenchmarkTMFmtLoggerSimple-2              200000              5427 ns/op             273 B/op        9 allocs/op
BenchmarkTMFmtLoggerContextual-2          200000              6455 ns/op             481 B/op       13 allocs/op

BenchmarkTMLoggerSimple-2                 200000              6083 ns/op             752 B/op         17 allocs/op
BenchmarkTMLoggerContextual-2             200000              6221 ns/op            1104 B/op         23 allocs/op
BenchmarkTMFmtLoggerSimple-2              300000              4892 ns/op             273 B/op          9 allocs/op
BenchmarkTMFmtLoggerContextual-2          200000              5874 ns/op             481 B/op         13 allocs/op
```

**Cons**:
- `tmfmt_logger` now knows about the `module` key and that there could be multiple values.

The same thing could be implemented via a new wrapper (similar to filter API `NewFilter(logger, ...)`) which has a `map[interface{}]interface{}` to hold unique keyvalue pairs https://gist.github.com/melekes/a662c8f7809626f1911a20c5672a6228. But having a map will result in twice more memory!