### PR TITLE
CLI Execute Error prints to stderr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+*.swp
 vendor
 .glide

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
+
 ## Develop-Branch changes (unreleased)
 
 BREAKING CHANGES:
 
 - [run] NewBaseService takes the new logger
+- [cli] RunCaptureWithArgs now captures stderr and stdout
+  - +func RunCaptureWithArgs(cmd Executable, args []string, env map[string]string) (stdout, stderr string, err error)
+  - -func RunCaptureWithArgs(cmd Executable, args []string, env map[string]string) (output string, err error) 
 
 ## 0.2.1 (June 2, 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Develop-Branch changes (unreleased)
+
+BREAKING CHANGES:
+
+- [run] NewBaseService takes the new logger
+
 ## 0.2.1 (June 2, 2017)
 
 FEATURES:

--- a/cli/helper.go
+++ b/cli/helper.go
@@ -54,9 +54,10 @@ func RunWithArgs(cmd Executable, args []string, env map[string]string) error {
 	return cmd.Execute()
 }
 
-// RunCaptureWithArgs executes the given command with the specified command line args
-// and environmental variables set. It returns whatever was writen to
-// stdout along with any error returned from cmd.Execute()
+// RunCaptureWithArgs executes the given command with the specified command
+// line args and environmental variables set. It returns string fields
+// representing output written to stdout and stderr, additionally any error
+// from cmd.Execute() is also returned
 func RunCaptureWithArgs(cmd Executable, args []string, env map[string]string) (stdout, stderr string, err error) {
 	oldout, olderr := os.Stdout, os.Stderr // keep backup of the real stdout
 	rOut, wOut, _ := os.Pipe()

--- a/cli/helper.go
+++ b/cli/helper.go
@@ -73,13 +73,13 @@ func RunCaptureWithArgs(cmd Executable, args []string, env map[string]string) (s
 		go func() {
 			var buf bytes.Buffer
 			// io.Copy will end when we call reader.Close() below
-			io.Copy(&buf, *reader)
+			io.Copy(&buf, reader)
 			stdC <- buf.String()
 		}()
-		return stdC
+		return &stdC
 	}
-	outC := copyStd(&rOut)
-	errC := copyStd(&rErr)
+	outC := copyStd(rOut)
+	errC := copyStd(rErr)
 
 	// now run the command
 	err = RunWithArgs(cmd, args, env)
@@ -87,7 +87,7 @@ func RunCaptureWithArgs(cmd Executable, args []string, env map[string]string) (s
 	// and grab the stdout to return
 	wOut.Close()
 	wErr.Close()
-	stdout = <-outC
-	stderr = <-errC
+	stdout = <-*outC
+	stderr = <-*errC
 	return stdout, stderr, err
 }

--- a/cli/setup.go
+++ b/cli/setup.go
@@ -93,9 +93,9 @@ func (e Executor) Execute() error {
 	if err != nil {
 		// TODO: something cooler with log-levels
 		if viper.GetBool(TraceFlag) {
-			fmt.Printf("ERROR: %+v\n", err)
+			fmt.Fprintf(os.Stderr, "ERROR: %+v\n", err)
 		} else {
-			fmt.Println("ERROR:", err.Error())
+			fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
 		}
 	}
 	return err

--- a/cli/setup_test.go
+++ b/cli/setup_test.go
@@ -212,9 +212,11 @@ func TestSetupTrace(t *testing.T) {
 
 		viper.Reset()
 		args := append([]string{cmd.Use}, tc.args...)
-		out, err := RunCaptureWithArgs(cmd, args, tc.env)
+		stdout, stderr, err := RunCaptureWithArgs(cmd, args, tc.env)
 		require.NotNil(err, i)
-		msg := strings.Split(out, "\n")
+		require.Equal("", stdout, i)
+		require.NotEqual("", stderr, i)
+		msg := strings.Split(stderr, "\n")
 		desired := fmt.Sprintf("ERROR: %s", tc.expected)
 		assert.Equal(desired, msg[0], i)
 		if tc.long && assert.True(len(msg) > 2, i) {


### PR DESCRIPTION
instead of stdout as before, very useful for bash processing/error checking for CLI testing