### PR TITLE
db: fix MemDB.Close

### DIFF
--- a/db/mem_db.go
+++ b/db/mem_db.go
@@ -52,9 +52,11 @@ func (db *MemDB) DeleteSync(key []byte) {
 }
 
 func (db *MemDB) Close() {
-	db.mtx.Lock()
-	defer db.mtx.Unlock()
-	db = nil
+	// Close is a noop since for an in-memory
+	// database, we don't have a destination
+	// to flush contents to nor do we want
+	// any data loss on invoking Close()
+	// See the discussion in https://github.com/tendermint/tmlibs/pull/56
 }
 
 func (db *MemDB) Print() {

--- a/db/mem_db_test.go
+++ b/db/mem_db_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMemDbIterator(t *testing.T) {
@@ -25,4 +26,23 @@ func TestMemDbIterator(t *testing.T) {
 		i += 1
 	}
 	assert.Equal(t, i, len(db.db), "iterator didnt cover whole db")
+}
+
+func TestMemDBClose(t *testing.T) {
+	db := NewMemDB()
+	copyDB := func(orig map[string][]byte) map[string][]byte {
+		copy := make(map[string][]byte)
+		for k, v := range orig {
+			copy[k] = v
+		}
+		return copy
+	}
+	k, v := []byte("foo"), []byte("bar")
+	db.Set(k, v)
+	require.Equal(t, db.Get(k), v, "expecting a successful get")
+	copyBefore := copyDB(db.db)
+	db.Close()
+	require.Equal(t, db.Get(k), v, "Close is a noop, expecting a successful get")
+	copyAfter := copyDB(db.db)
+	require.Equal(t, copyBefore, copyAfter, "Close is a noop and shouldn't modify any internal data")
 }


### PR DESCRIPTION
Fixes https://github.com/tendermint/tmlibs/issues/55

MemDB previously mistakenly set the actual DB pointer to nil
although that side effect is not visible to the outside world
since p is an identifier within the scope of just that function
call. The proper fix is to delete the underlying data map.