### PR TITLE
WIP: Improve db interface

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -11,6 +11,7 @@ type DB interface {
 	Close()
 	NewBatch() Batch
 	Iterator() Iterator
+	IteratorPrefix([]byte) Iterator
 
 	// For debugging
 	Print()

--- a/db/db.go
+++ b/db/db.go
@@ -10,10 +10,10 @@ type DB interface {
 	DeleteSync([]byte)
 	Close()
 	NewBatch() Batch
+	Iterator() Iterator
 
 	// For debugging
 	Print()
-	Iterator() Iterator
 	Stats() map[string]string
 }
 
@@ -28,6 +28,9 @@ type Iterator interface {
 
 	Key() []byte
 	Value() []byte
+
+	Release()
+	Error() error
 }
 
 //-----------------------------------------------------------------------------

--- a/db/go_level_db.go
+++ b/db/go_level_db.go
@@ -121,6 +121,7 @@ type goLevelDBIterator struct {
 	iterator.Iterator
 }
 
+// Key returns a copy of the current key.
 func (it *goLevelDBIterator) Key() []byte {
 	key := it.Key()
 	k := make([]byte, len(key))
@@ -129,6 +130,7 @@ func (it *goLevelDBIterator) Key() []byte {
 	return k
 }
 
+// Value returns a copy of the current value.
 func (it *goLevelDBIterator) Value() []byte {
 	val := it.Value()
 	v := make([]byte, len(val))

--- a/db/go_level_db.go
+++ b/db/go_level_db.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/errors"
+	"github.com/syndtr/goleveldb/leveldb/iterator"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/syndtr/goleveldb/leveldb/util"
 
@@ -116,12 +117,32 @@ func (db *GoLevelDB) Stats() map[string]string {
 	return stats
 }
 
+type goLevelDBIterator struct {
+	iterator.Iterator
+}
+
+func (it *goLevelDBIterator) Key() []byte {
+	key := it.Key()
+	k := make([]byte, len(key))
+	copy(k, key)
+
+	return k
+}
+
+func (it *goLevelDBIterator) Value() []byte {
+	val := it.Value()
+	v := make([]byte, len(val))
+	copy(v, val)
+
+	return v
+}
+
 func (db *GoLevelDB) Iterator() Iterator {
-	return db.db.NewIterator(nil, nil)
+	return &goLevelDBIterator{db.db.NewIterator(nil, nil)}
 }
 
 func (db *GoLevelDB) IteratorPrefix(prefix []byte) Iterator {
-	return db.db.NewIterator(util.BytesPrefix(prefix), nil)
+	return &goLevelDBIterator{db.db.NewIterator(util.BytesPrefix(prefix), nil)}
 }
 
 func (db *GoLevelDB) NewBatch() Batch {

--- a/db/go_level_db.go
+++ b/db/go_level_db.go
@@ -7,6 +7,7 @@ import (
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/errors"
 	"github.com/syndtr/goleveldb/leveldb/opt"
+	"github.com/syndtr/goleveldb/leveldb/util"
 
 	. "github.com/tendermint/tmlibs/common"
 )
@@ -117,6 +118,10 @@ func (db *GoLevelDB) Stats() map[string]string {
 
 func (db *GoLevelDB) Iterator() Iterator {
 	return db.db.NewIterator(nil, nil)
+}
+
+func (db *GoLevelDB) IteratorPrefix(prefix []byte) Iterator {
+	return db.db.NewIterator(util.BytesPrefix(prefix), nil)
 }
 
 func (db *GoLevelDB) NewBatch() Batch {

--- a/db/mem_db.go
+++ b/db/mem_db.go
@@ -97,6 +97,16 @@ func (it *memDBIterator) Value() []byte {
 	return it.db.Get(it.Key())
 }
 
+func (it *memDBIterator) Release() {
+	it.db = nil
+	it.keys = nil
+	return
+}
+
+func (it *memDBIterator) Error() error {
+	return nil
+}
+
 func (db *MemDB) Iterator() Iterator {
 	it := newMemDBIterator()
 	it.db = db

--- a/db/mem_db.go
+++ b/db/mem_db.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 )
 
@@ -108,6 +109,10 @@ func (it *memDBIterator) Error() error {
 }
 
 func (db *MemDB) Iterator() Iterator {
+	return db.IteratorPrefix([]byte{})
+}
+
+func (db *MemDB) IteratorPrefix(prefix []byte) Iterator {
 	it := newMemDBIterator()
 	it.db = db
 	it.last = -1
@@ -117,7 +122,9 @@ func (db *MemDB) Iterator() Iterator {
 
 	// unfortunately we need a copy of all of the keys
 	for key, _ := range db.db {
-		it.keys = append(it.keys, key)
+		if strings.HasPrefix(key, string(prefix)) {
+			it.keys = append(it.keys, key)
+		}
 	}
 	return it
 }


### PR DESCRIPTION
I would like to improve the DB interface to move some of the complexity down a layer, instead of having to deal with it when using the library. Currently, to achieve this, I have to do a type assertion and handle two cases manually (memdb and goleveldb). Also important to note that we don't expose Release() at the moment, which means the leveldb iterators could leak. We're going to be using the iterator feature a lot for historical queries, so this needs to be tight.