### PR TITLE
STALLED: db: add BadgerDB

### DIFF
--- a/db/badger_db.go
+++ b/db/badger_db.go
@@ -1,0 +1,323 @@
+// Copyright 2017 Tendermint. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// BadgerDB enables us the use of BadgerDB a fast key value store in pure Go.
+// Typical usage follows:
+//  db, err := db.NewBadgerDB("badger", targetDir)
+//  if err != nil {
+//	log.Fatalf("badgerDB initialization: %v", err)
+//  }
+//  defer db.Close()
+//
+//  For the asynchronous set
+//  db.Set([]byte("foo"), []byte("bar"))
+//  db.SetSync([]byte("true"), []byte("tendermint"))
+//  db.Delete([]byte("true"))
+//  db.Deletesync([]byte("true"))
+//  iter := db.Iterator()
+//  for {
+//     key, value := iter.Key(), iter.Value()
+//     fmt.Printf("key: %v value: %v\n", key, value)
+//  }
+//
+// For better performance, perform Sets/Writes in batches
+//  batch := db.NewBatch()
+//  for i := 0; i < 100; i++ {
+//	batch.Set(cmn.RandBytes(100), []byte("true!!!"))
+//  }
+//  batch.Write()
+
+package db
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/dgraph-io/badger"
+
+	"github.com/tendermint/tmlibs/common"
+)
+
+func init() {
+	registerDBCreator(BadgerDBBackendStr, badgerDBCreator, true)
+}
+
+type Options badger.Options
+
+func badgerDBCreator(dbName, dir string) (DB, error) {
+	return NewBadgerDB(dbName, dir)
+}
+
+var (
+	_KB = int64(1024)
+	_MB = 1024 * _KB
+	_GB = 1024 * _MB
+)
+
+// NewBadgerDB creates a Badger key-value store backed to the
+// directory dir supplied. If dir does not exist, we create it.
+func NewBadgerDB(dbName, dir string) (*BadgerDB, error) {
+	// BadgerDB doesn't expose a way for us to
+	// create  a DB with the user's supplied name.
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, err
+	}
+	opts := new(badger.Options)
+	*opts = badger.DefaultOptions
+	// Arbitrary size given that at Tendermint
+	// we'll need huge KeyValue stores.
+	opts.ValueLogFileSize = 1 * _GB
+	opts.Dir = dir
+	opts.ValueDir = dir
+
+	return NewBadgerDBWithOptions((*Options)(opts))
+}
+
+// NewBadgerDBWithOptions creates a BadgerDB key value store
+// gives the flexibility of initializing a database with the
+// respective options.
+func NewBadgerDBWithOptions(opts *Options) (*BadgerDB, error) {
+	kv, err := badger.NewKV((*badger.Options)(opts))
+	if err != nil {
+		return nil, err
+	}
+	return &BadgerDB{kv: kv}, nil
+}
+
+type BadgerDB struct {
+	kv *badger.KV
+}
+
+var _ DB = (*BadgerDB)(nil)
+
+func (b *BadgerDB) Get(key []byte) []byte {
+	valueItem := new(badger.KVItem)
+	if err := b.kv.Get(key, valueItem); err != nil {
+		// Unfortunate that Get can't return errors
+		// TODO: Propose allowing DB's Get to return errors too.
+		common.PanicCrisis(err)
+	}
+	var valueSave []byte
+	err := valueItem.Value(func(origValue []byte) error {
+		// TODO: Decide if we should just assign valueSave to origValue
+		// since here we aren't dealing with iterators directly.
+		valueSave = make([]byte, len(origValue))
+		copy(valueSave, origValue)
+		return nil
+	})
+	if err != nil {
+		// TODO: ditto:: Propose allowing DB's Get to return errors too.
+		common.PanicCrisis(err)
+	}
+	return valueSave
+}
+
+// noUserMeta signifies blank metadata for a kv entry
+// since badger.Set accepts an optional userMeta field
+var noUserMeta byte = 0x00
+
+func panicOnErr(err error) {
+	if err != nil {
+		common.PanicCrisis(err)
+	}
+}
+
+func (b *BadgerDB) Set(key, value []byte) {
+	b.kv.SetAsync(key, value, noUserMeta, panicOnErr)
+}
+
+func (b *BadgerDB) SetSync(key, value []byte) {
+	if err := b.kv.Set(key, value, noUserMeta); err != nil {
+		common.PanicCrisis(err)
+	}
+}
+
+func (b *BadgerDB) Delete(key []byte) {
+	b.kv.DeleteAsync(key, panicOnErr)
+}
+
+func (b *BadgerDB) DeleteSync(key []byte) {
+	if err := b.kv.Delete(key); err != nil {
+		common.PanicCrisis(err)
+	}
+}
+
+func (b *BadgerDB) Close() {
+	if err := b.kv.Close(); err != nil {
+		common.PanicCrisis(err)
+	}
+}
+
+func (b *BadgerDB) Fprint(w io.Writer) {
+	bIter := b.Iterator().(*badgerDBIterator)
+	defer bIter.Close()
+
+	var bw *bufio.Writer
+	if bbw, ok := w.(*bufio.Writer); ok {
+		bw = bbw
+	} else {
+		bw = bufio.NewWriter(w)
+	}
+	defer bw.Flush()
+
+	i := uint64(0)
+	for bIter.rewind(); bIter.valid(); bIter.Next() {
+		k, v := bIter.kv()
+		fmt.Fprintf(bw, "[%X]:\t[%X]\n", k, v)
+		i += 1
+		if i%1024 == 0 {
+			bw.Flush()
+			i = 0
+		}
+	}
+}
+
+func (b *BadgerDB) Print() {
+	bw := bufio.NewWriter(os.Stdout)
+	b.Fprint(bw)
+}
+
+func (b *BadgerDB) Iterator() Iterator {
+	dbIter := b.kv.NewIterator(badger.IteratorOptions{
+		PrefetchValues: true,
+
+		// Arbitrary PrefetchSize
+		PrefetchSize: 10,
+	})
+	// Ensure that we are always at the zeroth item
+	dbIter.Rewind()
+	return &badgerDBIterator{iter: dbIter}
+}
+
+func (b *BadgerDB) Stats() map[string]string {
+	return nil
+}
+
+func (b *BadgerDB) NewBatch() Batch {
+	return &badgerDBBatch{db: b}
+}
+
+var _ Batch = (*badgerDBBatch)(nil)
+
+type badgerDBBatch struct {
+	entriesMu sync.Mutex
+	entries   []*badger.Entry
+
+	db *BadgerDB
+}
+
+func (bb *badgerDBBatch) Set(key, value []byte) {
+	bb.entriesMu.Lock()
+	bb.entries = append(bb.entries, &badger.Entry{
+		Key:   key,
+		Value: value,
+	})
+	bb.entriesMu.Unlock()
+}
+
+// Unfortunately Badger doesn't have a batch delete
+// The closest that we can do is do a delete from the DB.
+// Hesitant to do DeleteAsync because that changes the
+// expected ordering
+func (bb *badgerDBBatch) Delete(key []byte) {
+	bb.db.Delete(key)
+}
+
+// Write commits all batch sets to the DB
+func (bb *badgerDBBatch) Write() {
+	bb.entriesMu.Lock()
+	entries := bb.entries
+	bb.entries = nil
+	bb.entriesMu.Unlock()
+
+	if len(entries) == 0 {
+		return
+	}
+	if err := bb.db.kv.BatchSet(entries); err != nil {
+		common.PanicCrisis(err)
+	}
+
+	var buf *bytes.Buffer // It'll be lazily allocated when needed
+	for i, entry := range entries {
+		if err := entry.Error; err != nil {
+			if buf == nil {
+				buf = new(bytes.Buffer)
+			}
+			fmt.Fprintf(buf, "#%d: entry err: %v\n", i, err)
+		}
+	}
+	if buf != nil {
+		common.PanicCrisis(string(buf.Bytes()))
+	}
+}
+
+type badgerDBIterator struct {
+	mu sync.RWMutex
+
+	iter *badger.Iterator
+}
+
+var _ Iterator = (*badgerDBIterator)(nil)
+
+func (bi *badgerDBIterator) Next() bool {
+	if !bi.iter.Valid() {
+		return false
+	}
+	bi.iter.Next()
+	return bi.iter.Valid()
+}
+
+func (bi *badgerDBIterator) Key() []byte { return bi.iter.Item().Key() }
+func (bi *badgerDBIterator) Value() []byte {
+	var valueSave []byte
+	err := bi.iter.Item().Value(func(origValue []byte) error {
+		valueSave = make([]byte, len(origValue))
+		copy(valueSave, origValue)
+		return nil
+	})
+	if err != nil {
+		// TODO: ditto:: Propose allowing DB's Get to return errors too.
+		common.PanicCrisis(err)
+	}
+	return valueSave
+}
+
+func (bi *badgerDBIterator) kv() (key, value []byte) {
+	var valueSave []byte
+	bItem := bi.iter.Item()
+	if bItem == nil {
+		return nil, nil
+	}
+	err := bItem.Value(func(origValue []byte) error {
+		valueSave = make([]byte, len(origValue))
+		copy(valueSave, origValue)
+		return nil
+	})
+	if err != nil {
+		// TODO: ditto:: Propose allowing DB's Get to return errors too.
+		common.PanicCrisis(err)
+	}
+	return bItem.Key(), valueSave
+}
+
+func (bi *badgerDBIterator) Close() {
+	bi.iter.Close()
+}
+
+func (bi *badgerDBIterator) rewind()     { bi.iter.Rewind() }
+func (bi *badgerDBIterator) valid() bool { return bi.iter.Valid() }

--- a/db/badger_db_test.go
+++ b/db/badger_db_test.go
@@ -85,7 +85,7 @@ func TestBadgerDBSetGet(t *testing.T) {
 
 	for i, tt := range tests {
 		if got := ddb.Get(tt.key); !bytes.Equal(got, nil) {
-			t.Errorf("#%d: Get mismatch\ngot: %x\nwant:nil", i, got, nil)
+			t.Errorf("#%d: Get mismatch\ngot: %x\nwant:nil", i, got)
 		}
 	}
 }
@@ -183,13 +183,13 @@ func TestBadgerDBBatchSet(t *testing.T) {
 	// Verify that no keys have been committed yet.
 	for i, tt := range tests {
 		if got := ddb.Get(tt.key); !bytes.Equal(got, nil) {
-			t.Errorf("#%d: Get mismatch\ngot: %x\nwant:nil", i, got, nil)
+			t.Errorf("#%d: Get mismatch\ngot: %x\nwant:nil", i, got)
 		}
 	}
 
 	batch.Write()
 
-	// Now ensure that wrote the data
+	// Now ensure that we wrote the data
 	for i, tt := range tests {
 		if got, want := ddb.Get(tt.key), tt.value; !bytes.Equal(got, want) {
 			t.Errorf("#%d: Get mismatch\ngot: %x\nwant:%x", i, got, want)

--- a/db/badger_db_test.go
+++ b/db/badger_db_test.go
@@ -1,0 +1,325 @@
+// Copyright 2017 Tendermint. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tendermint/tmlibs/common"
+	"github.com/tendermint/tmlibs/db"
+)
+
+func setupBadgerDB(t *testing.T) (d db.DB, tearDown func()) {
+	testDir, err := ioutil.TempDir("", "throwaway-db-tests")
+	require.Nil(t, err, "expecting a nil error")
+	ddb := db.NewDB("test_db", db.BadgerDBBackendStr, testDir)
+	tearDown = func() {
+		ddb.Close()
+		os.RemoveAll(testDir)
+	}
+	return ddb, tearDown
+}
+
+func TestBadgerDB(t *testing.T) {
+	t.Parallel()
+
+	ddb, tearDown := setupBadgerDB(t)
+	defer tearDown()
+
+	switch ddb.(type) {
+	case *db.BadgerDB:
+	default:
+		t.Fatalf("expected a proper DB initialization")
+	}
+}
+
+func TestBadgerDBSetGet(t *testing.T) {
+	t.Parallel()
+
+	ddb, tearDown := setupBadgerDB(t)
+	defer tearDown()
+
+	tests := []struct {
+		key, value []byte
+	}{
+		{key: []byte("foo"), value: []byte("bar")},
+		{key: []byte("                                          "), value: []byte("")},
+		{key: []byte(""), value: []byte("                                          ")},
+		{key: []byte(" "), value: []byte("a                                         2")},
+		{key: common.RandBytes(1024), value: []byte("right here ")},
+	}
+
+	for _, tt := range tests {
+		ddb.SetSync(tt.key, tt.value)
+	}
+
+	for i, tt := range tests {
+		if got, want := ddb.Get(tt.key), tt.value; !bytes.Equal(got, want) {
+			t.Errorf("#%d: Get mismatch\ngot: %x\nwant:%x", i, got, want)
+		}
+	}
+
+	// Purge them all
+	for _, tt := range tests {
+		ddb.DeleteSync(tt.key)
+	}
+
+	for i, tt := range tests {
+		if got := ddb.Get(tt.key); !bytes.Equal(got, nil) {
+			t.Errorf("#%d: Get mismatch\ngot: %x\nwant:nil", i, got, nil)
+		}
+	}
+}
+
+func TestBadgerDBFprint(t *testing.T) {
+	t.Parallel()
+
+	adb, tearDown := setupBadgerDB(t)
+	defer tearDown()
+
+	ddb := adb.(*db.BadgerDB)
+
+	// Initially no data
+	buf := new(bytes.Buffer)
+	ddb.Fprint(buf)
+	require.Equal(t, 0, len(buf.Bytes()), "unexpected data here: %s", buf.Bytes())
+
+	tests := []struct {
+		key, value []byte
+	}{
+		{key: []byte("foo"), value: []byte("bar")},
+		{key: []byte("                                          "), value: []byte("")},
+		{key: []byte(" "), value: []byte("a                                         2")},
+		{key: common.RandBytes(1024), value: []byte("right here ")},
+		{key: nil, value: common.RandBytes(1024)},
+		{key: []byte("p"), value: []byte("                                          ")},
+		{key: common.RandBytes(511), value: nil},
+	}
+
+	batch := ddb.NewBatch()
+	for _, tt := range tests {
+		batch.Set(tt.key, tt.value)
+	}
+	batch.Write()
+
+	ddb.Fprint(buf)
+
+	// To ensure that all the entries match, nothing less, nothing more
+	// We'll iterate through the DB, printing out entries to a log
+	// and afterwards go through the expected entries, trimming
+	// out existent entries and at the end the remaining log should
+	// be entirely empty
+
+	rawLog := buf.Bytes()
+	require.NotEqual(t, 0, len(rawLog), "expecting log entries")
+
+	for i, tt := range tests {
+		require.NotEqual(t, 0, len(rawLog), "#%d log unexpectedly is of length 0", i)
+
+		wantKey, wantValue := tt.key, tt.value
+		wantEntry := []byte(fmt.Sprintf("[%X]:\t[%X]\n", wantKey, wantValue))
+		index := bytes.Index(rawLog, wantEntry)
+		if index < 0 {
+			t.Errorf("#%d: could not find entry %q. current log: %q", i, wantEntry, rawLog)
+			continue
+		}
+
+		// Otherwise now prune out that entry to trim the log
+		rawLog = bytes.Join([][]byte{rawLog[:index], rawLog[index+len(wantEntry):]}, []byte(""))
+	}
+}
+
+func TestBadgerDBBatchSet(t *testing.T) {
+	t.Parallel()
+
+	ddb, tearDown := setupBadgerDB(t)
+	defer tearDown()
+
+	tests := []struct {
+		key, value []byte
+	}{
+		{key: []byte("foo"), value: []byte("bar")},
+		{key: []byte("                                          "), value: []byte("")},
+		{key: []byte(" "), value: []byte("a                                         2")},
+		{key: common.RandBytes(1024), value: []byte("right here ")},
+		{key: nil, value: common.RandBytes(1024)},
+		{key: []byte("p"), value: []byte("                                          ")},
+		{key: common.RandBytes(511), value: nil},
+	}
+
+	batch := ddb.NewBatch()
+
+	// Test concurrent batch sets and
+	// ensure that we don't have an races.
+	var wg sync.WaitGroup
+	for _, tt := range tests {
+		wg.Add(1)
+		go func(key, value []byte) {
+			defer wg.Done()
+			batch.Set(key, value)
+		}(tt.key, tt.value)
+	}
+	wg.Wait()
+
+	// Verify that no keys have been committed yet.
+	for i, tt := range tests {
+		if got := ddb.Get(tt.key); !bytes.Equal(got, nil) {
+			t.Errorf("#%d: Get mismatch\ngot: %x\nwant:nil", i, got, nil)
+		}
+	}
+
+	batch.Write()
+
+	// Now ensure that wrote the data
+	for i, tt := range tests {
+		if got, want := ddb.Get(tt.key), tt.value; !bytes.Equal(got, want) {
+			t.Errorf("#%d: Get mismatch\ngot: %x\nwant:%x", i, got, want)
+		}
+	}
+}
+
+func TestBadgerDBIterator(t *testing.T) {
+	t.Parallel()
+
+	ddb, tearDown := setupBadgerDB(t)
+	defer tearDown()
+
+	tests := []struct {
+		key, value []byte
+	}{
+		{key: []byte("foo"), value: []byte("bar")},
+		{key: []byte("                                          "), value: []byte("")},
+		{key: []byte(" "), value: []byte("a                                         2")},
+		{key: common.RandBytes(1024), value: []byte("right here ")},
+		{key: nil, value: common.RandBytes(1024)},
+		{key: []byte("p"), value: []byte("                                          ")},
+		{key: common.RandBytes(511), value: nil},
+	}
+
+	batch := ddb.NewBatch()
+	for _, tt := range tests {
+		batch.Set(tt.key, tt.value)
+	}
+	batch.Write()
+
+	// To ensure that all the entries match, nothing less, nothing more
+	// We'll iterate through the DB, printing out entries to a log
+	// and afterwards go through the expected entries, trimming
+	// out existent entries and at the end the remaining log should
+	// be entirely empty
+	iter := ddb.Iterator()
+	resultLog := new(bytes.Buffer)
+	for {
+		gotKey, gotValue := iter.Key(), iter.Value()
+		fmt.Fprintf(resultLog, "%x:%x\n", gotKey, gotValue)
+		if !iter.Next() {
+			break
+		}
+	}
+
+	rawLog := resultLog.Bytes()
+	require.NotEqual(t, 0, len(rawLog), "expecting log entries")
+
+	for i, tt := range tests {
+		require.NotEqual(t, 0, len(rawLog), "#%d log unexpectedly is of length 0", i)
+
+		wantKey, wantValue := tt.key, tt.value
+		wantEntry := []byte(fmt.Sprintf("%x:%x\n", wantKey, wantValue))
+		index := bytes.Index(rawLog, wantEntry)
+		if index < 0 {
+			t.Errorf("#%d: could not find entry %q. current log: %q", i, wantEntry, rawLog)
+			continue
+		}
+
+		// Otherwise now prune out that entry to trim the log
+		rawLog = bytes.Join([][]byte{rawLog[:index], rawLog[index+len(wantEntry):]}, []byte(""))
+	}
+	require.Equal(t, 0, len(rawLog), "expected all log entries to have been matched and trimmed out")
+}
+
+var benchmarkData = []struct {
+	key, value []byte
+}{
+	{common.RandBytes(100), nil},
+	{common.RandBytes(1000), []byte("foo")},
+	{[]byte("foo"), common.RandBytes(1000)},
+	{[]byte(""), common.RandBytes(1000)},
+	{nil, common.RandBytes(1000000)},
+	{common.RandBytes(100000), nil},
+	{common.RandBytes(1000000), nil},
+}
+
+func BenchmarkBadgerDBSet(b *testing.B) {
+	ddb, tearDown := setupBadgerDB(nil)
+	defer tearDown()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, tt := range benchmarkData {
+			ddb.Set(tt.key, tt.value)
+		}
+	}
+	b.ReportAllocs()
+}
+
+func BenchmarkBadgerDBSetSync(b *testing.B) {
+	ddb, tearDown := setupBadgerDB(nil)
+	defer tearDown()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, tt := range benchmarkData {
+			ddb.SetSync(tt.key, tt.value)
+		}
+	}
+	b.ReportAllocs()
+}
+
+func BenchmarkBadgerDBBatchSet(b *testing.B) {
+	ddb, tearDown := setupBadgerDB(nil)
+	defer tearDown()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		batch := ddb.NewBatch()
+		for _, tt := range benchmarkData {
+			batch.Set(tt.key, tt.value)
+		}
+		batch.Write()
+	}
+	b.ReportAllocs()
+}
+
+func BenchmarkBadgerDBSetDelete(b *testing.B) {
+	ddb, tearDown := setupBadgerDB(nil)
+	defer tearDown()
+
+	for i := 0; i < b.N; i++ {
+		for _, tt := range benchmarkData {
+			ddb.Set(tt.key, tt.value)
+		}
+		for _, tt := range benchmarkData {
+			ddb.Delete(tt.key)
+		}
+	}
+	b.ReportAllocs()
+}

--- a/db/c_level_db_test.go
+++ b/db/c_level_db_test.go
@@ -72,15 +72,3 @@ func BenchmarkRandomReadsWrites2(b *testing.B) {
 
 	db.Close()
 }
-
-/*
-func int642Bytes(i int64) []byte {
-	buf := make([]byte, 8)
-	binary.BigEndian.PutUint64(buf, uint64(i))
-	return buf
-}
-
-func bytes2Int64(buf []byte) int64 {
-	return int64(binary.BigEndian.Uint64(buf))
-}
-*/

--- a/db/common_benchmarks_test.go
+++ b/db/common_benchmarks_test.go
@@ -1,0 +1,125 @@
+package db_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	cmn "github.com/tendermint/tmlibs/common"
+	"github.com/tendermint/tmlibs/db"
+)
+
+var benchmarkData = []struct {
+	key, value []byte
+}{
+	{cmn.RandBytes(100), nil},
+	{cmn.RandBytes(1000), []byte("foo")},
+	{[]byte("foo"), cmn.RandBytes(1000)},
+	{[]byte(""), cmn.RandBytes(1000)},
+	{nil, cmn.RandBytes(1000000)},
+	{cmn.RandBytes(100000), nil},
+	{cmn.RandBytes(1000000), nil},
+}
+
+func benchmarkRandomReadsWritesOnDB(b *testing.B, db db.DB) {
+	numItems := int64(1000000)
+	internal := map[int64]int64{}
+	b.StopTimer()
+	for i := 0; i < int(numItems); i++ {
+		internal[int64(i)] = int64(0)
+	}
+
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		// Write something
+		{
+			idx := (int64(cmn.RandInt()) % numItems)
+			internal[idx] += 1
+			val := internal[idx]
+			idxBytes := int642Bytes(int64(idx))
+			valBytes := int642Bytes(int64(val))
+			db.SetSync(idxBytes, valBytes)
+		}
+
+		// Read something
+		{
+			idx := (int64(cmn.RandInt()) % numItems)
+			val := internal[idx]
+			idxBytes := int642Bytes(int64(idx))
+			valBytes := db.Get(idxBytes)
+			if val == 0 {
+				if !bytes.Equal(valBytes, nil) {
+					b.Errorf("Expected %v for %v, got %X",
+						nil, idx, valBytes)
+					break
+				}
+			} else {
+				if len(valBytes) != 8 {
+					b.Errorf("Expected length 8 for %v, got %X",
+						idx, valBytes)
+					break
+				}
+				valGot := bytes2Int64(valBytes)
+				if val != valGot {
+					b.Errorf("Expected %v for %v, got %v",
+						val, idx, valGot)
+					break
+				}
+			}
+		}
+	}
+	b.ReportAllocs()
+}
+
+func benchmarkSetDelete(b *testing.B, db db.DB) {
+	b.Skip("Until https://github.com/dgraph-io/badger/issues/308 is resolved, this benchmark is invalid")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, tt := range benchmarkData {
+			db.SetSync(tt.key, tt.value)
+		}
+		for _, tt := range benchmarkData {
+			db.Delete(tt.key)
+		}
+	}
+	b.ReportAllocs()
+}
+
+func benchmarkBatchSetDelete(b *testing.B, db db.DB) {
+	b.ResetTimer()
+	batch := db.NewBatch()
+	for i := 0; i < b.N; i++ {
+		for _, tt := range benchmarkData {
+			batch.Set(tt.key, tt.value)
+		}
+		batch.Write()
+		for _, tt := range benchmarkData {
+			batch.Delete(tt.key)
+		}
+	}
+	b.ReportAllocs()
+}
+
+func benchmarkBatchSet(b *testing.B, db db.DB) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		batch := db.NewBatch()
+		for _, tt := range benchmarkData {
+			batch.Set(tt.key, tt.value)
+		}
+		batch.Write()
+	}
+	b.ReportAllocs()
+}
+
+func int642Bytes(i int64) []byte {
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, uint64(i))
+	return buf
+}
+
+func bytes2Int64(buf []byte) int64 {
+	return int64(binary.BigEndian.Uint64(buf))
+}

--- a/db/db.go
+++ b/db/db.go
@@ -41,6 +41,7 @@ const (
 	CLevelDBBackendStr  = "cleveldb"
 	GoLevelDBBackendStr = "goleveldb"
 	MemDBBackendStr     = "memdb"
+	BadgerDBBackendStr  = "badger"
 )
 
 type dbCreator func(name string, dir string) (DB, error)

--- a/db/example_test.go
+++ b/db/example_test.go
@@ -1,0 +1,38 @@
+// Copyright 2017 Tendermint. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db_test
+
+import (
+	"log"
+
+	"github.com/tendermint/tmlibs/common"
+	"github.com/tendermint/tmlibs/db"
+)
+
+func Example_BadgerDB() {
+	db, err := db.NewBadgerDB("badger", "./throwaway-dir")
+	if err != nil {
+		log.Fatalf("badgerDB: %v", err)
+	}
+	defer db.Close()
+
+	db.SetSync([]byte("issaDB"), []byte("true!!!"))
+
+	batch := db.NewBatch()
+	for i := 0; i < 1000; i++ {
+		batch.Set(common.RandBytes(10), []byte("filled up"))
+	}
+	batch.Write()
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,16 @@
-hash: 6efda1f3891a7211fc3dc1499c0079267868ced9739b781928af8e225420f867
-updated: 2017-08-11T20:28:34.550901198Z
+hash: 834046467149739bb34d9933dc8be4a1a2413d2753439847c3e8ff86a30ea47b
+updated: 2017-11-04T05:18:05.644323137Z
 imports:
+- name: github.com/AndreasBriese/bbloom
+  version: 28f7e881ca57bc00e028f9ede9f0d9104cfeef5e
+- name: github.com/dgraph-io/badger
+  version: 7f945c8fffd35e73f278fc3f0bce9961398dc1e1
+  subpackages:
+  - options
+  - protos
+  - skl
+  - table
+  - "y"
 - name: github.com/fsnotify/fsnotify
   version: 4da3e2cfbabc9f751898f250b49f2439785783a1
 - name: github.com/go-kit/kit
@@ -15,12 +25,14 @@ imports:
   version: 1e5f1161c6416a5ff48840eb8724a394e48cc534
   subpackages:
   - currency
-- name: github.com/dgraph-io/badger
-  version: 7f945c8fffd35e73f278fc3f0bce9961398dc1e1
 - name: github.com/go-playground/universal-translator
   version: 71201497bace774495daed26a3874fd339e0b538
 - name: github.com/go-stack/stack
   version: 7a2f19628aabfe68f0766b59e74d6315f8347d22
+- name: github.com/golang/protobuf
+  version: 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9
+  subpackages:
+  - proto
 - name: github.com/golang/snappy
   version: 553a641470496b2327abcac10b36396bd98e45c9
 - name: github.com/hashicorp/hcl
@@ -96,6 +108,12 @@ imports:
   version: 5a033cc77e57eca05bdb50522851d29e03569cbe
   subpackages:
   - ripemd160
+- name: golang.org/x/net
+  version: 01c190206fbdffa42f334f4b2bf2220f50e64920
+  subpackages:
+  - context
+  - internal/timeseries
+  - trace
 - name: golang.org/x/sys
   version: 9ccfe848b9db8435a24c424abbc07a921adf1df5
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -15,6 +15,8 @@ imports:
   version: 1e5f1161c6416a5ff48840eb8724a394e48cc534
   subpackages:
   - currency
+- name: github.com/dgraph-io/badger
+  version: 7f945c8fffd35e73f278fc3f0bce9961398dc1e1
 - name: github.com/go-playground/universal-translator
   version: 71201497bace774495daed26a3874fd339e0b538
 - name: github.com/go-stack/stack

--- a/glide.lock
+++ b/glide.lock
@@ -4,7 +4,7 @@ imports:
 - name: github.com/AndreasBriese/bbloom
   version: 28f7e881ca57bc00e028f9ede9f0d9104cfeef5e
 - name: github.com/dgraph-io/badger
-  version: 7f945c8fffd35e73f278fc3f0bce9961398dc1e1
+  version: 6c5c93205b5571967bd2efb350697947ad942221
   subpackages:
   - options
   - protos

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,6 +10,7 @@ import:
 - package: github.com/pkg/errors
 - package: github.com/spf13/cobra
 - package: github.com/spf13/viper
+- package: github.com/dgraph-io/badger
 - package: github.com/syndtr/goleveldb
   subpackages:
   - leveldb

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,6 @@
 package: github.com/tendermint/tmlibs
 import:
+- package: github.com/dgraph-io/badger
 - package: github.com/go-kit/kit
   subpackages:
   - log
@@ -10,12 +11,13 @@ import:
 - package: github.com/pkg/errors
 - package: github.com/spf13/cobra
 - package: github.com/spf13/viper
-- package: github.com/dgraph-io/badger
 - package: github.com/syndtr/goleveldb
   subpackages:
   - leveldb
   - leveldb/errors
+  - leveldb/iterator
   - leveldb/opt
+  - leveldb/util
 - package: github.com/tendermint/go-wire
   subpackages:
   - data
@@ -27,7 +29,6 @@ import:
 - package: gopkg.in/go-playground/validator.v9
 testImport:
 - package: github.com/stretchr/testify
-  version: ^1.1.4
   subpackages:
   - assert
   - require


### PR DESCRIPTION
Updates https://github.com/tendermint/tmlibs/issues/30

Adds a backend for BadgerDB as requested at
https://github.com/tendermint/tmlibs/issues/30#issue-241573231
and tests for it along.

BadgerDB has a few problems:
a) It doesn't have a BatchDelete, our fallback is thus Delete
because if do DeleteAsync, by the time batch.Write is invoked,
we can't be sure that the deletions have ran
b) Retrieving values from iterators requires a secondary allocation
equal to the length of the current key.
See https://godoc.org/github.com/dgraph-io/badger#KV.NewIterator
c) It seems to have arbitrary options for the size of the
log file varying between 10MB to 2GB. Currently with our
DB API, we can't pass in the required file size unless we
invoke:
```go
db.NewBadgerDBWithOptions(&db.Options{
  ValueLogFileSize: desiredFileSize,
})
```

Anyways, I've arbitrarily set the default value log file size to 1GB
given that Tendermint does a whole lot of heavy lifting with
keyvalue stores <-- cite my sources