### PR TITLE
Fix zeroed buffer getting flushed to the empty event

### DIFF
--- a/events/event_cache.go
+++ b/events/event_cache.go
@@ -1,9 +1,5 @@
 package events
 
-const (
-	eventsBufferSize = 1000
-)
-
 // An EventCache buffers events for a Fireable
 // All events are cached. Filtering happens on Flush
 type EventCache struct {
@@ -14,8 +10,7 @@ type EventCache struct {
 // Create a new EventCache with an EventSwitch as backend
 func NewEventCache(evsw Fireable) *EventCache {
 	return &EventCache{
-		evsw:   evsw,
-		events: make([]eventInfo, eventsBufferSize),
+		evsw: evsw,
 	}
 }
 
@@ -27,7 +22,7 @@ type eventInfo struct {
 
 // Cache an event to be fired upon finality.
 func (evc *EventCache) FireEvent(event string, data EventData) {
-	// append to list
+	// append to list (go will grow our backing array exponentially)
 	evc.events = append(evc.events, eventInfo{event, data})
 }
 
@@ -37,5 +32,6 @@ func (evc *EventCache) Flush() {
 	for _, ei := range evc.events {
 		evc.evsw.FireEvent(ei.event, ei.data)
 	}
-	evc.events = make([]eventInfo, eventsBufferSize)
+	// Clear the buffer, since we only add to it with append it's safe to just set it to nil and maybe safe an allocation
+	evc.events = nil
 }

--- a/events/event_cache_test.go
+++ b/events/event_cache_test.go
@@ -1,0 +1,35 @@
+package events
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventCache_Flush(t *testing.T) {
+	evsw := NewEventSwitch()
+	evsw.Start()
+	evsw.AddListenerForEvent("nothingness", "", func(data EventData) {
+		// Check we are not initialising an empty buffer full of zeroed eventInfos in the EventCache
+		require.FailNow(t, "We should never receive a message on this switch since none are fired")
+	})
+	evc := NewEventCache(evsw)
+	evc.Flush()
+	// Check after reset
+	evc.Flush()
+	fail := true
+	pass := false
+	evsw.AddListenerForEvent("somethingness", "something", func(data EventData) {
+		if fail {
+			require.FailNow(t, "Shouldn't see a message until flushed")
+		}
+		pass = true
+	})
+	evc.FireEvent("something", struct{ int }{1})
+	evc.FireEvent("something", struct{ int }{2})
+	evc.FireEvent("something", struct{ int }{3})
+	fail = false
+	evc.Flush()
+	assert.True(t, pass)
+}


### PR DESCRIPTION
You'll only notice this if you accidentally subscribe to the empty event (`""`) on Tendermint, but your `EventCache` implementation has a bug in that every time `Flush` is called it sends a prefix of 1000 empty events to the `EventSwitch` before sending the events it should have been buffering. Given this happens about every second it might not be an insignificant performance hit.

It looks like a guess was being made at a good size to have the buffer's backing array as 1000. I suggest we drop this as it is arbitrary and Go should do a good job of exponentially growing our arrays. If we do have a clear median on the number of events that will get buffered then it makes to set the backing array capacity to that number, but I suspect this is a premature optimisation. To do that we should use:

```go
evc.events = make([]eventInfo, 0, eventsBufferSize)
```

To give the backing array the desire capacity but set the length to 0 so we don't have a big empty prefix in our buffer and the first `append` adds at position 0.