### PR TITLE
Refactor throttle timer

### DIFF
--- a/common/repeat_timer_test.go
+++ b/common/repeat_timer_test.go
@@ -43,7 +43,7 @@ func TestRepeat(test *testing.T) {
 	short := time.Duration(20) * time.Millisecond
 	// delay waits for cnt durations, an a little extra
 	delay := func(cnt int) time.Duration {
-		return time.Duration(cnt)*dur + time.Millisecond
+		return time.Duration(cnt)*dur + time.Duration(5)*time.Millisecond
 	}
 	t := NewRepeatTimer("bar", dur)
 

--- a/common/throttle_timer.go
+++ b/common/throttle_timer.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"fmt"
 	"time"
 )
 
@@ -64,7 +63,6 @@ func (t *ThrottleTimer) run() {
 // happen in this method. It is only called from the run goroutine
 // so we avoid any race conditions
 func (t *ThrottleTimer) processInput(cmd command) (shutdown bool) {
-	fmt.Printf("processInput: %d\n", cmd)
 	switch cmd {
 	case Set:
 		if !t.isSet {
@@ -77,9 +75,7 @@ func (t *ThrottleTimer) processInput(cmd command) (shutdown bool) {
 	case Unset:
 		if t.isSet {
 			t.isSet = false
-			if !t.timer.Stop() {
-				<-t.timer.C
-			}
+			t.timer.Stop()
 		}
 	default:
 		panic("unknown command!")

--- a/common/throttle_timer.go
+++ b/common/throttle_timer.go
@@ -52,8 +52,8 @@ func (t *ThrottleTimer) run() {
 		select {
 		case cmd := <-t.input:
 			// stop goroutine if the input says so
+			// don't close channels, as closed channels mess up select reads
 			if t.processInput(cmd) {
-				close(t.Ch)
 				return
 			}
 		case <-t.timer.C:

--- a/common/throttle_timer_test.go
+++ b/common/throttle_timer_test.go
@@ -49,7 +49,7 @@ func TestThrottle(test *testing.T) {
 	t := NewThrottleTimer("foo", delay)
 
 	// start at 0
-	c := &thCounter{input: t.C()}
+	c := &thCounter{input: t.Ch}
 	assert.Equal(0, c.Count())
 	go c.Read()
 

--- a/common/throttle_timer_test.go
+++ b/common/throttle_timer_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 type thCounter struct {
-	input chan struct{}
+	input <-chan struct{}
 	mtx   sync.Mutex
 	count int
 }

--- a/common/throttle_timer_test.go
+++ b/common/throttle_timer_test.go
@@ -31,6 +31,9 @@ func (c *thCounter) Count() int {
 // Read should run in a go-routine and
 // updates count by one every time a packet comes in
 func (c *thCounter) Read() {
+	// note, since this channel never closes, this will never end
+	// if thCounter was used in anything beyond trivial test cases.
+	// it would have to be smarter.
 	for range c.input {
 		c.Increment()
 	}

--- a/common/throttle_timer_test.go
+++ b/common/throttle_timer_test.go
@@ -46,7 +46,7 @@ func TestThrottle(test *testing.T) {
 	t := NewThrottleTimer("foo", delay)
 
 	// start at 0
-	c := &thCounter{input: t.Ch}
+	c := &thCounter{input: t.C()}
 	assert.Equal(0, c.Count())
 	go c.Read()
 


### PR DESCRIPTION
As I was reviewing abci, I came across throttle timer, which seemed very confusing code to me, in that it mixed mutex and channel, and accessed state across multiple goroutines (some generated internally to the time package via AfterFunc). I added tests and proved to myself it worked properly, but I wanted to try my hand at refactoring it. One for cleaner code, and also for me to get more comfortable with how goroutines and channels are used in tendermint code.

I would like a review with one of three outcomes:

* The new code is broken - here's why
* The new code works, but it is not better than the old code - here's why
* The new code works, and is cleaner than the old code

In any case, it will be a learning experience for me. If you like it, merge it. If not, please explain why the previous state was better, so I can write similar code.