### PR TITLE
Refactor repeat timer

### DIFF
--- a/common/repeat_timer.go
+++ b/common/repeat_timer.go
@@ -68,20 +68,20 @@ func (t *RepeatTimer) run() {
 			// don't close channels, as closed channels mess up select reads
 			done = t.processInput(cmd)
 		case tick := <-t.ticker.C:
-			t.trySend(tick)
+			t.send(tick)
 		}
 	}
 }
 
-// trySend performs non-blocking send on t.Ch
-func (t *RepeatTimer) trySend(tick time.Time) {
-	// NOTE: this was blocking in previous version (t.Ch <- t_)
-	// probably better not: https://golang.org/src/time/sleep.go#L132
-	t.output <- tick
+// send performs blocking send on t.Ch
+func (t *RepeatTimer) send(tick time.Time) {
+	// XXX: possibly it is better to not block:
+	// https://golang.org/src/time/sleep.go#L132
 	// select {
 	// case t.output <- tick:
 	// default:
 	// }
+	t.output <- tick
 }
 
 // all modifications of the internal state of ThrottleTimer

--- a/common/repeat_timer_test.go
+++ b/common/repeat_timer_test.go
@@ -39,11 +39,11 @@ func (c *rCounter) Read() {
 func TestRepeat(test *testing.T) {
 	assert := asrt.New(test)
 
-	dur := time.Duration(50) * time.Millisecond
+	dur := time.Duration(100) * time.Millisecond
 	short := time.Duration(20) * time.Millisecond
 	// delay waits for cnt durations, an a little extra
 	delay := func(cnt int) time.Duration {
-		return time.Duration(cnt)*dur + time.Duration(5)*time.Millisecond
+		return time.Duration(cnt)*dur + time.Duration(10)*time.Millisecond
 	}
 	t := NewRepeatTimer("bar", dur)
 
@@ -70,7 +70,7 @@ func TestRepeat(test *testing.T) {
 	// after a stop, nothing more is sent
 	stopped := t.Stop()
 	assert.True(stopped)
-	time.Sleep(delay(7))
+	time.Sleep(delay(2))
 	assert.Equal(6, c.Count())
 
 	// extra calls to stop don't block

--- a/common/repeat_timer_test.go
+++ b/common/repeat_timer_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 type rCounter struct {
-	input chan time.Time
+	input <-chan time.Time
 	mtx   sync.Mutex
 	count int
 }
@@ -74,5 +74,5 @@ func TestRepeat(test *testing.T) {
 	assert.Equal(6, c.Count())
 
 	// close channel to stop counter
-	close(t.Ch)
+	t.Stop()
 }

--- a/common/repeat_timer_test.go
+++ b/common/repeat_timer_test.go
@@ -73,6 +73,6 @@ func TestRepeat(test *testing.T) {
 	time.Sleep(delay(7))
 	assert.Equal(6, c.Count())
 
-	// close channel to stop counter
+	// extra calls to stop don't block
 	t.Stop()
 }

--- a/common/throttle_timer.go
+++ b/common/throttle_timer.go
@@ -22,7 +22,7 @@ type ThrottleTimer struct {
 	stopped bool
 }
 
-type throttleCommand int32
+type throttleCommand int8
 
 const (
 	Set throttleCommand = iota
@@ -83,7 +83,6 @@ func (t *ThrottleTimer) processInput(cmd throttleCommand) (shutdown bool) {
 			t.timer.Reset(t.dur)
 		}
 	case TQuit:
-		t.stopped = true
 		shutdown = true
 		fallthrough
 	case Unset:
@@ -125,5 +124,6 @@ func (t *ThrottleTimer) Stop() bool {
 		return false
 	}
 	t.input <- TQuit
+	t.stopped = true
 	return true
 }

--- a/common/throttle_timer.go
+++ b/common/throttle_timer.go
@@ -13,7 +13,7 @@ at most once every "dur".
 type ThrottleTimer struct {
 	Name   string
 	Ch     <-chan struct{}
-	input  chan command
+	input  chan throttleCommand
 	output chan<- struct{}
 	dur    time.Duration
 
@@ -21,12 +21,12 @@ type ThrottleTimer struct {
 	isSet bool
 }
 
-type command int32
+type throttleCommand int32
 
 const (
-	Set command = iota
+	Set throttleCommand = iota
 	Unset
-	Quit
+	TQuit
 )
 
 // NewThrottleTimer creates a new ThrottleTimer.
@@ -36,7 +36,7 @@ func NewThrottleTimer(name string, dur time.Duration) *ThrottleTimer {
 		Name:   name,
 		Ch:     c,
 		dur:    dur,
-		input:  make(chan command),
+		input:  make(chan throttleCommand),
 		output: c,
 		timer:  time.NewTimer(dur),
 	}
@@ -74,14 +74,14 @@ func (t *ThrottleTimer) trySend() {
 // all modifications of the internal state of ThrottleTimer
 // happen in this method. It is only called from the run goroutine
 // so we avoid any race conditions
-func (t *ThrottleTimer) processInput(cmd command) (shutdown bool) {
+func (t *ThrottleTimer) processInput(cmd throttleCommand) (shutdown bool) {
 	switch cmd {
 	case Set:
 		if !t.isSet {
 			t.isSet = true
 			t.timer.Reset(t.dur)
 		}
-	case Quit:
+	case TQuit:
 		shutdown = true
 		fallthrough
 	case Unset:
@@ -122,6 +122,6 @@ func (t *ThrottleTimer) Stop() bool {
 	if t == nil {
 		return false
 	}
-	t.input <- Quit
+	t.input <- TQuit
 	return true
 }

--- a/common/throttle_timer.go
+++ b/common/throttle_timer.go
@@ -17,8 +17,9 @@ type ThrottleTimer struct {
 	output chan<- struct{}
 	dur    time.Duration
 
-	timer *time.Timer
-	isSet bool
+	timer   *time.Timer
+	isSet   bool
+	stopped bool
 }
 
 type throttleCommand int32
@@ -82,6 +83,7 @@ func (t *ThrottleTimer) processInput(cmd throttleCommand) (shutdown bool) {
 			t.timer.Reset(t.dur)
 		}
 	case TQuit:
+		t.stopped = true
 		shutdown = true
 		fallthrough
 	case Unset:
@@ -119,7 +121,7 @@ func (t *ThrottleTimer) Unset() {
 // For ease of stopping services before starting them, we ignore Stop on nil
 // ThrottleTimers.
 func (t *ThrottleTimer) Stop() bool {
-	if t == nil {
+	if t == nil || t.stopped {
 		return false
 	}
 	t.input <- TQuit

--- a/common/throttle_timer_test.go
+++ b/common/throttle_timer_test.go
@@ -95,4 +95,9 @@ func TestThrottle(test *testing.T) {
 
 	stopped := t.Stop()
 	assert.True(stopped)
+	time.Sleep(longwait)
+	assert.Equal(5, c.Count())
+
+	// extra calls to stop don't block
+	t.Stop()
 }

--- a/common/throttle_timer_test.go
+++ b/common/throttle_timer_test.go
@@ -95,9 +95,6 @@ func TestThrottle(test *testing.T) {
 
 	stopped := t.Stop()
 	assert.True(stopped)
-	time.Sleep(longwait)
-	assert.Equal(5, c.Count())
-
 	// extra calls to stop don't block
 	t.Stop()
 }


### PR DESCRIPTION
Same cleanup (remove mutex, use command channel) as with throttle timer.
Made the output non-blocking as per time.Ticker
Made Stop idemnepotent