### PR TITLE
WIP Changed Service interface

### DIFF
--- a/common/service_test.go
+++ b/common/service_test.go
@@ -4,13 +4,9 @@ import (
 	"testing"
 )
 
-func TestBaseServiceWait(t *testing.T) {
+func TestBaseService(t *testing.T) {
 
-	type TestService struct {
-		BaseService
-	}
-	ts := &TestService{}
-	ts.BaseService = *NewBaseService(nil, "TestService", ts)
+	ts := NewBaseService(nil, "TestService", &testServiceCore{})
 	ts.Start()
 
 	go func() {
@@ -18,7 +14,17 @@ func TestBaseServiceWait(t *testing.T) {
 	}()
 
 	for i := 0; i < 10; i++ {
-		ts.Wait()
+		ts.wait()
 	}
 
+}
+
+type testServiceCore struct{}
+
+func (tc *testServiceCore) OnStart() error {
+	return nil
+}
+
+func (tc *testServiceCore) OnStop() error {
+	return nil
 }


### PR DESCRIPTION
Service could be much simplified.
We shouldn't be masking race conditions by letting the caller call Start/Stop willy nilly.  If one needs to rely on such patterns, it's probably because one has racy buggy software.

Now that we know better, lets refactor and test Tendermint to see how racy it is.

We don't use Restart as far as I know.