### PR TITLE
common: fix BitArray.Update to avoid nil dereference

### DIFF
--- a/common/bit_array.go
+++ b/common/bit_array.go
@@ -306,7 +306,7 @@ func (bA *BitArray) Bytes() []byte {
 // so if necessary, caller must copy or lock o prior to calling Update.
 // If bA is nil, does nothing.
 func (bA *BitArray) Update(o *BitArray) {
-	if bA == nil {
+	if bA == nil || o == nil {
 		return
 	}
 	bA.mtx.Lock()

--- a/common/bit_array_test.go
+++ b/common/bit_array_test.go
@@ -164,3 +164,26 @@ func TestEmptyFull(t *testing.T) {
 		}
 	}
 }
+
+func TestUpdateNeverPanics(t *testing.T) {
+	newRandBitArray := func(n int) *BitArray {
+		ba, _ := randBitArray(n)
+		return ba
+	}
+	pairs := []struct {
+		a, b *BitArray
+	}{
+		{nil, nil},
+		{newRandBitArray(10), newRandBitArray(12)},
+		{newRandBitArray(0), NewBitArray(10)},
+		{nil, NewBitArray(10)},
+		{nil, newRandBitArray(64)},
+		{newRandBitArray(63), newRandBitArray(64)},
+	}
+
+	for _, pair := range pairs {
+		a, b := pair.a, pair.b
+		a.Update(b)
+		b.Update(a)
+	}
+}

--- a/common/bit_array_test.go
+++ b/common/bit_array_test.go
@@ -175,10 +175,9 @@ func TestUpdateNeverPanics(t *testing.T) {
 	}{
 		{nil, nil},
 		{newRandBitArray(10), newRandBitArray(12)},
-		{newRandBitArray(0), NewBitArray(10)},
+		{newRandBitArray(23), newRandBitArray(23)},
+		{newRandBitArray(37), nil},
 		{nil, NewBitArray(10)},
-		{nil, newRandBitArray(64)},
-		{newRandBitArray(63), newRandBitArray(64)},
 	}
 
 	for _, pair := range pairs {


### PR DESCRIPTION
Update previously only checked that the receiver was
non-nil but didn't check that the input parameter to update
"o" was non-nil causing a nil dereference in cases such as
https://github.com/tendermint/tendermint/blob/fe632ea32a89c3d9804bbd6e3ce9391b1d5a0993/consensus/reactor.go#L306

Fixes https://github.com/tendermint/tendermint/issues/1169