### PR TITLE
merkle: remove go-wire dep by copying EncodeByteSlice

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,6 @@
-hash: 22e22759d9adc51e3ce0728955143321386891907ce54eb952245d57285d8784
-updated: 2018-02-02T23:47:17.788237939-05:00
+hash: 98752078f39da926f655268b3b143f713d64edd379fc9fcb1210d9d8aa7ab4e0
+updated: 2018-02-03T01:28:00.221548057-05:00
 imports:
-- name: github.com/davecgh/go-spew
-  version: 346938d642f2ec3594ed81d874461961cd0faa76
-  subpackages:
-  - spew
 - name: github.com/fsnotify/fsnotify
   version: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
 - name: github.com/go-kit/kit
@@ -79,8 +75,6 @@ imports:
   - leveldb/storage
   - leveldb/table
   - leveldb/util
-- name: github.com/tendermint/go-wire
-  version: dec83f641903b22f039da3974607859715d0377e
 - name: golang.org/x/crypto
   version: edd5e9b0879d13ee6970a50153d85b8fec9f7686
   subpackages:
@@ -97,6 +91,10 @@ imports:
 - name: gopkg.in/yaml.v2
   version: d670f9405373e636a5a2765eea47fac0c9bc91a4
 testImports:
+- name: github.com/davecgh/go-spew
+  version: 346938d642f2ec3594ed81d874461961cd0faa76
+  subpackages:
+  - spew
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -26,8 +26,6 @@ import:
   - leveldb/errors
   - leveldb/iterator
   - leveldb/opt
-- package: github.com/tendermint/go-wire
-  version: develop
 - package: golang.org/x/crypto
   subpackages:
   - ripemd160

--- a/merkle/simple_map.go
+++ b/merkle/simple_map.go
@@ -1,7 +1,6 @@
 package merkle
 
 import (
-	"github.com/tendermint/go-wire"
 	cmn "github.com/tendermint/tmlibs/common"
 	"golang.org/x/crypto/ripemd160"
 )
@@ -65,11 +64,11 @@ type kvPair cmn.KVPair
 
 func (kv kvPair) Hash() []byte {
 	hasher := ripemd160.New()
-	err := wire.EncodeByteSlice(hasher, kv.Key)
+	err := encodeByteSlice(hasher, kv.Key)
 	if err != nil {
 		panic(err)
 	}
-	err = wire.EncodeByteSlice(hasher, kv.Value)
+	err = encodeByteSlice(hasher, kv.Value)
 	if err != nil {
 		panic(err)
 	}

--- a/merkle/simple_tree.go
+++ b/merkle/simple_tree.go
@@ -26,14 +26,12 @@ package merkle
 
 import (
 	"golang.org/x/crypto/ripemd160"
-
-	"github.com/tendermint/go-wire"
 )
 
 func SimpleHashFromTwoHashes(left []byte, right []byte) []byte {
 	var hasher = ripemd160.New()
-	err := wire.EncodeByteSlice(hasher, left)
-	err = wire.EncodeByteSlice(hasher, right)
+	err := encodeByteSlice(hasher, left)
+	err = encodeByteSlice(hasher, right)
 	if err != nil {
 		panic(err)
 	}

--- a/merkle/types.go
+++ b/merkle/types.go
@@ -1,5 +1,10 @@
 package merkle
 
+import (
+	"encoding/binary"
+	"io"
+)
+
 type Tree interface {
 	Size() (size int)
 	Height() (height int8)
@@ -20,4 +25,23 @@ type Tree interface {
 
 type Hasher interface {
 	Hash() []byte
+}
+
+//-----------------------------------------------------------------------
+// NOTE: these are duplicated from go-wire so we dont need go-wire as a dep
+
+func encodeByteSlice(w io.Writer, bz []byte) (err error) {
+	err = encodeVarint(w, int64(len(bz)))
+	if err != nil {
+		return
+	}
+	_, err = w.Write(bz)
+	return
+}
+
+func encodeVarint(w io.Writer, i int64) (err error) {
+	var buf [10]byte
+	n := binary.PutVarint(buf[:], i)
+	_, err = w.Write(buf[0:n])
+	return
 }


### PR DESCRIPTION
:D 