### PR TITLE
Fix byteslice encoding for SimpleMap

### DIFF
--- a/events/README.md
+++ b/events/README.md
@@ -95,7 +95,7 @@ type EventCallback func(data EventData)
 type EventData interface {
 }
 ```
-Generic event data can be typed and registered with tendermint/go-wire
+Generic event data can be typed and registered with tendermint/go-amino
 via concrete implementation of this interface
 
 

--- a/events/events.go
+++ b/events/events.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/tendermint/tmlibs/common"
 )
 
-// Generic event data can be typed and registered with tendermint/go-wire
+// Generic event data can be typed and registered with tendermint/go-amino
 // via concrete implementation of this interface
 type EventData interface {
 	//AssertIsEventData()

--- a/merkle/simple_map_test.go
+++ b/merkle/simple_map_test.go
@@ -17,37 +17,37 @@ func TestSimpleMap(t *testing.T) {
 	{
 		db := NewSimpleMap()
 		db.Set("key1", strHasher("value1"))
-		assert.Equal(t, "19618304d1ad2635c4238bce87f72331b22a11a1", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
+		assert.Equal(t, "acdb4f121bc6f25041eb263ab463f1cd79236a32", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
 	}
 	{
 		db := NewSimpleMap()
 		db.Set("key1", strHasher("value2"))
-		assert.Equal(t, "51cb96d3d41e1714def72eb4bacc211de9ddf284", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
+		assert.Equal(t, "b8cbf5adee8c524e14f531da9b49adbbbd66fffa", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
 	}
 	{
 		db := NewSimpleMap()
 		db.Set("key1", strHasher("value1"))
 		db.Set("key2", strHasher("value2"))
-		assert.Equal(t, "58a0a99d5019fdcad4bcf55942e833b2dfab9421", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
+		assert.Equal(t, "1708aabc85bbe00242d3db8c299516aa54e48c38", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
 	}
 	{
 		db := NewSimpleMap()
 		db.Set("key2", strHasher("value2")) // NOTE: out of order
 		db.Set("key1", strHasher("value1"))
-		assert.Equal(t, "58a0a99d5019fdcad4bcf55942e833b2dfab9421", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
+		assert.Equal(t, "1708aabc85bbe00242d3db8c299516aa54e48c38", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
 	}
 	{
 		db := NewSimpleMap()
 		db.Set("key1", strHasher("value1"))
 		db.Set("key2", strHasher("value2"))
 		db.Set("key3", strHasher("value3"))
-		assert.Equal(t, "cb56db3c7993e977f4c2789559ae3e5e468a6e9b", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
+		assert.Equal(t, "e728afe72ce351eed6aca65c5f78da19b9a6e214", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
 	}
 	{
 		db := NewSimpleMap()
 		db.Set("key2", strHasher("value2")) // NOTE: out of order
 		db.Set("key1", strHasher("value1"))
 		db.Set("key3", strHasher("value3"))
-		assert.Equal(t, "cb56db3c7993e977f4c2789559ae3e5e468a6e9b", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
+		assert.Equal(t, "e728afe72ce351eed6aca65c5f78da19b9a6e214", fmt.Sprintf("%x", db.Hash()), "Hash didn't match")
 	}
 }

--- a/merkle/types.go
+++ b/merkle/types.go
@@ -28,10 +28,10 @@ type Hasher interface {
 }
 
 //-----------------------------------------------------------------------
-// NOTE: these are duplicated from go-wire so we dont need go-wire as a dep
+// NOTE: these are duplicated from go-amino so we dont need go-amino as a dep
 
 func encodeByteSlice(w io.Writer, bz []byte) (err error) {
-	err = encodeVarint(w, int64(len(bz)))
+	err = encodeUvarint(w, uint64(len(bz)))
 	if err != nil {
 		return
 	}
@@ -39,9 +39,9 @@ func encodeByteSlice(w io.Writer, bz []byte) (err error) {
 	return
 }
 
-func encodeVarint(w io.Writer, i int64) (err error) {
+func encodeUvarint(w io.Writer, i uint64) (err error) {
 	var buf [10]byte
-	n := binary.PutVarint(buf[:], i)
+	n := binary.PutUvarint(buf[:], i)
 	_, err = w.Write(buf[0:n])
 	return
 }


### PR DESCRIPTION
When we removed the go-wire dependency, ByteSlice was using varints.  We now use uvarints exclusively to encode the length of items to follow.

We probably won't have these issues anymore, but it's worth noting that we almost forgot to fix this.... we'll just need to write more integration tests.