### PR TITLE
dont length prefix hashes during concatenation

### DIFF
--- a/merkle/simple_map.go
+++ b/merkle/simple_map.go
@@ -5,23 +5,27 @@ import (
 	"github.com/tendermint/tmlibs/merkle/tmhash"
 )
 
-type SimpleMap struct {
+// Merkle tree from a map.
+// Leaves are `hash(key) | hash(value)`.
+// Leaves are sorted before Merkle hashing.
+type simpleMap struct {
 	kvs    cmn.KVPairs
 	sorted bool
 }
 
-func NewSimpleMap() *SimpleMap {
-	return &SimpleMap{
+func newSimpleMap() *simpleMap {
+	return &simpleMap{
 		kvs:    nil,
 		sorted: false,
 	}
 }
 
-func (sm *SimpleMap) Set(key string, value Hasher) {
+// Hash the key and value and append to the kv pairs
+func (sm *simpleMap) Set(key string, value Hasher) {
 	sm.sorted = false
 
 	// Hash the key to blind it... why not?
-	khash := SimpleHashFromBytes([]byte(key))
+	khash := tmhash.Sum([]byte(key))
 
 	// And the value is hashed too, so you can
 	// check for equality with a cached value (say)
@@ -36,12 +40,12 @@ func (sm *SimpleMap) Set(key string, value Hasher) {
 
 // Merkle root hash of items sorted by key
 // (UNSTABLE: and by value too if duplicate key).
-func (sm *SimpleMap) Hash() []byte {
+func (sm *simpleMap) Hash() []byte {
 	sm.Sort()
 	return hashKVPairs(sm.kvs)
 }
 
-func (sm *SimpleMap) Sort() {
+func (sm *simpleMap) Sort() {
 	if sm.sorted {
 		return
 	}
@@ -50,7 +54,8 @@ func (sm *SimpleMap) Sort() {
 }
 
 // Returns a copy of sorted KVPairs.
-func (sm *SimpleMap) KVPairs() cmn.KVPairs {
+// NOTE these contain the hashed key and value.
+func (sm *simpleMap) KVPairs() cmn.KVPairs {
 	sm.Sort()
 	kvs := make(cmn.KVPairs, len(sm.kvs))
 	copy(kvs, sm.kvs)
@@ -60,25 +65,19 @@ func (sm *SimpleMap) KVPairs() cmn.KVPairs {
 //----------------------------------------
 
 // A local extension to KVPair that can be hashed.
-type KVPair cmn.KVPair
+// XXX: key and value must already be hashed -
+// otherwise the kvpair ("abc", "def") would give the same result
+// as ("ab", "cdef") since we're not using length-prefixing.
+type kvPair cmn.KVPair
 
-func (kv KVPair) Hash() []byte {
-	hasher := tmhash.New()
-	err := encodeByteSlice(hasher, kv.Key)
-	if err != nil {
-		panic(err)
-	}
-	err = encodeByteSlice(hasher, kv.Value)
-	if err != nil {
-		panic(err)
-	}
-	return hasher.Sum(nil)
+func (kv kvPair) Hash() []byte {
+	return SimpleHashFromTwoHashes(kv.Key, kv.Value)
 }
 
 func hashKVPairs(kvs cmn.KVPairs) []byte {
-	kvsH := make([]Hasher, 0, len(kvs))
-	for _, kvp := range kvs {
-		kvsH = append(kvsH, KVPair(kvp))
+	kvsH := make([]Hasher, len(kvs))
+	for i, kvp := range kvs {
+		kvsH[i] = kvPair(kvp)
 	}
 	return SimpleHashFromHashers(kvsH)
 }

--- a/merkle/simple_proof.go
+++ b/merkle/simple_proof.go
@@ -23,7 +23,7 @@ func SimpleProofsFromHashers(items []Hasher) (rootHash []byte, proofs []*SimpleP
 }
 
 func SimpleProofsFromMap(m map[string]Hasher) (rootHash []byte, proofs []*SimpleProof) {
-	sm := NewSimpleMap()
+	sm := newSimpleMap()
 	for k, v := range m {
 		sm.Set(k, v)
 	}
@@ -31,7 +31,7 @@ func SimpleProofsFromMap(m map[string]Hasher) (rootHash []byte, proofs []*Simple
 	kvs := sm.kvs
 	kvsH := make([]Hasher, 0, len(kvs))
 	for _, kvp := range kvs {
-		kvsH = append(kvsH, KVPair(kvp))
+		kvsH = append(kvsH, kvPair(kvp))
 	}
 	return SimpleProofsFromHashers(kvsH)
 }

--- a/merkle/simple_tree.go
+++ b/merkle/simple_tree.go
@@ -28,19 +28,15 @@ import (
 	"github.com/tendermint/tmlibs/merkle/tmhash"
 )
 
+// Append the two hashes and hash them
 func SimpleHashFromTwoHashes(left []byte, right []byte) []byte {
 	var hasher = tmhash.New()
-	err := encodeByteSlice(hasher, left)
-	if err != nil {
-		panic(err)
-	}
-	err = encodeByteSlice(hasher, right)
-	if err != nil {
-		panic(err)
-	}
+	hasher.Write(left)
+	hasher.Write(right)
 	return hasher.Sum(nil)
 }
 
+// Expects hashes!
 func SimpleHashFromHashes(hashes [][]byte) []byte {
 	// Recursive impl.
 	switch len(hashes) {

--- a/merkle/simple_tree.go
+++ b/merkle/simple_tree.go
@@ -28,16 +28,40 @@ import (
 	"github.com/tendermint/tmlibs/merkle/tmhash"
 )
 
-// Append the two hashes and hash them
-func SimpleHashFromTwoHashes(left []byte, right []byte) []byte {
+// Hash(left | right). The basic operation of the Merkle tree.
+func SimpleHashFromTwoHashes(left, right []byte) []byte {
 	var hasher = tmhash.New()
 	hasher.Write(left)
 	hasher.Write(right)
 	return hasher.Sum(nil)
 }
 
+// Compute a Merkle tree from items that can be hashed.
+func SimpleHashFromHashers(items []Hasher) []byte {
+	hashes := make([][]byte, len(items))
+	for i, item := range items {
+		hash := item.Hash()
+		hashes[i] = hash
+	}
+	return simpleHashFromHashes(hashes)
+}
+
+// Compute a Merkle tree from sorted map.
+// Like calling SimpleHashFromHashers with
+// `item = []byte(Hash(key) | Hash(value))`,
+// sorted by `item`.
+func SimpleHashFromMap(m map[string]Hasher) []byte {
+	sm := newSimpleMap()
+	for k, v := range m {
+		sm.Set(k, v)
+	}
+	return sm.Hash()
+}
+
+//----------------------------------------------------------------
+
 // Expects hashes!
-func SimpleHashFromHashes(hashes [][]byte) []byte {
+func simpleHashFromHashes(hashes [][]byte) []byte {
 	// Recursive impl.
 	switch len(hashes) {
 	case 0:
@@ -45,43 +69,8 @@ func SimpleHashFromHashes(hashes [][]byte) []byte {
 	case 1:
 		return hashes[0]
 	default:
-		left := SimpleHashFromHashes(hashes[:(len(hashes)+1)/2])
-		right := SimpleHashFromHashes(hashes[(len(hashes)+1)/2:])
+		left := simpleHashFromHashes(hashes[:(len(hashes)+1)/2])
+		right := simpleHashFromHashes(hashes[(len(hashes)+1)/2:])
 		return SimpleHashFromTwoHashes(left, right)
 	}
-}
-
-// NOTE: Do not implement this, use SimpleHashFromByteslices instead.
-// type Byteser interface { Bytes() []byte }
-// func SimpleHashFromBytesers(items []Byteser) []byte { ... }
-
-func SimpleHashFromByteslices(bzs [][]byte) []byte {
-	hashes := make([][]byte, len(bzs))
-	for i, bz := range bzs {
-		hashes[i] = SimpleHashFromBytes(bz)
-	}
-	return SimpleHashFromHashes(hashes)
-}
-
-func SimpleHashFromBytes(bz []byte) []byte {
-	hasher := tmhash.New()
-	hasher.Write(bz)
-	return hasher.Sum(nil)
-}
-
-func SimpleHashFromHashers(items []Hasher) []byte {
-	hashes := make([][]byte, len(items))
-	for i, item := range items {
-		hash := item.Hash()
-		hashes[i] = hash
-	}
-	return SimpleHashFromHashes(hashes)
-}
-
-func SimpleHashFromMap(m map[string]Hasher) []byte {
-	sm := NewSimpleMap()
-	for k, v := range m {
-		sm.Set(k, v)
-	}
-	return sm.Hash()
 }

--- a/merkle/tmhash/hash.go
+++ b/merkle/tmhash/hash.go
@@ -34,8 +34,15 @@ func (h sha256trunc) BlockSize() int {
 	return h.sha256.BlockSize()
 }
 
+// New returns a new hash.Hash.
 func New() hash.Hash {
 	return sha256trunc{
 		sha256: sha256.New(),
 	}
+}
+
+// Sum returns the first 20 bytes of SHA256 of the bz.
+func Sum(bz []byte) []byte {
+	hash := sha256.Sum256(bz)
+	return hash[:Size]
 }


### PR DESCRIPTION
Trying to simplify the tree here.

I don't see what the length prefixing buys us, other than another dependency/thing to specify.

Of course, we still need it for hashing kv pairs, otherwise two distinct pairs could hash to the same thing. 

Can we enforce that these FromXxxHashes functions only work with hashes of the same length (ie so theyre safe to concatenate without length prefixing ) ? 

@zmanian @jaekwon @Liamsi 

Ref https://github.com/tendermint/tendermint/issues/1547